### PR TITLE
fix length of client message arguments on 64-bit

### DIFF
--- a/Graphics/X11/Xlib/Extras.hsc
+++ b/Graphics/X11/Xlib/Extras.hsc
@@ -601,7 +601,7 @@ getEvent p = do
                         16 -> do a <- peekArray 10 datPtr
                                  return $ map fromIntegral (a::[Word16])
                         32 -> do a <- peekArray 5 datPtr
-                                 return $ map fromIntegral (a::[Word32])
+                                 return $ map fromIntegral (a::[CLong])
                         _  -> error "X11.Extras.clientMessage: illegal value"
             return $ ClientMessageEvent
                         { ev_event_type    = type_


### PR DESCRIPTION
This is a proposed bug fix for a problem I ran into using xmonad client messages to send remote commands on 64LP architectures (i.e., amd64), wherein the C X11 library and Haskell's disagree about the size of client message arguments.

I sent this for the darcs repo and on haskell-cafe over a year ago but nothing every happened.

The XClientMessageEvent.data.l field is actually a long, not an int, so it must
be interpreted as such, even though format is set to 32 in this case.
Ostensibly this is an Xlib bug, but it is unlikely to be fixed there.
