### PR TITLE
Fix errors from changed FFI newtype behaviour in GHC7.6

### DIFF
--- a/Graphics/X11/Xlib/Event.hsc
+++ b/Graphics/X11/Xlib/Event.hsc
@@ -18,7 +18,7 @@ module Graphics.X11.Xlib.Event(
         queuedAlready,
         queuedAfterFlush,
         queuedAfterReading,
-        XEvent,
+        XEvent(..),
         XEventPtr,
         allocaXEvent,
         get_EventType,

--- a/Graphics/X11/Xrandr.hsc
+++ b/Graphics/X11/Xrandr.hsc
@@ -203,9 +203,9 @@ foreign import ccall "XRRSelectInput"
   cXRRSelectInput :: Display -> Window -> CInt -> IO ()
 
 xrrUpdateConfiguration :: XEvent -> IO CInt
-xrrUpdateConfiguration = cXRRUpdateConfiguration
+xrrUpdateConfiguration (XEvent e) = cXRRUpdateConfiguration e
 foreign import ccall "XRRUpdateConfiguration"
-  cXRRUpdateConfiguration :: XEvent -> IO CInt
+  cXRRUpdateConfiguration :: XEventPtr -> IO CInt
 
 xrrRotations :: Display -> CInt -> IO (Rotation, Rotation)
 xrrRotations dpy screen =


### PR DESCRIPTION
I'm not sure if this is the best approach (it makes the XEvent newtype somewhat useless by exporting its constructor), but this fixes the build.
