### PR TITLE
X11 XReadBitmap API support.

### DIFF
--- a/Graphics/X11/Xlib/Misc.hsc
+++ b/Graphics/X11/Xlib/Misc.hsc
@@ -761,7 +761,7 @@ foreign import ccall unsafe "HsXlib.h XBitmapPad"
 
 -- | interface to the X11 library function @XReadBitmapFile@.
 readBitmapFile :: Display -> Drawable -> String
-                  -> IO (Dimension, Dimension, Pixmap, Maybe CInt, Maybe CInt)
+                  -> IO (Either String (Dimension, Dimension, Pixmap, Maybe CInt, Maybe CInt))
 readBitmapFile display d filename =
   withCString filename $ \ c_filename ->
   alloca $ \ width_return ->
@@ -769,7 +769,7 @@ readBitmapFile display d filename =
   alloca $ \ bitmap_return ->
   alloca $ \ x_hot_return ->
   alloca $ \ y_hot_return -> do
-    _ <- xReadBitmapFile display d c_filename width_return height_return
+    rv <- xReadBitmapFile display d c_filename width_return height_return
          bitmap_return x_hot_return y_hot_return
     width <- peek width_return
     height <- peek height_return
@@ -780,7 +780,12 @@ readBitmapFile display d filename =
                 | otherwise  = Just x_hot
         m_y_hot | y_hot == -1 = Nothing
                 | otherwise  = Just y_hot
-    return (fromIntegral width, fromIntegral height, bitmap, m_x_hot, m_y_hot)
+    case rv of
+        0 -> return $ Right (fromIntegral width, fromIntegral height, bitmap, m_x_hot, m_y_hot)
+        1 -> return $ Left "readBitmapFile: BitmapOpenFailed"
+        2 -> return $ Left "readBitmapFile: BitmapFileInvalid"
+        3 -> return $ Left "readBitmapFile: BitmapNoMemory"
+        _ -> return $ Left "readBitmapFile: BitmapUnknownError"
 foreign import ccall unsafe "X11/Xlib.h XReadBitmapFile"
   xReadBitmapFile :: Display -> Drawable -> CString -> Ptr CInt -> Ptr CInt
                      -> Ptr Pixmap -> Ptr CInt -> Ptr CInt -> IO CInt


### PR DESCRIPTION
G'day,

This patch adds support for the libX11 XReadBitmapFile API. This resolve a downstream support use case issue for XmoBar github issue #87.

Background found here:
https://github.com/jaor/xmobar/pull/87

May we please merge this here upstream for other possible uses, perhaps in XMonad for example?

Kind Regards,
Edward O'Callaghan.
