### PR TITLE
Add wa_colormap to getWindowAttributes.

### DIFF
--- a/Graphics/X11/Xlib/Extras.hsc
+++ b/Graphics/X11/Xlib/Extras.hsc
@@ -978,7 +978,7 @@ foreign import ccall unsafe "XlibExtras.h XGetWindowAttributes"
 
 getWindowAttributes :: Display -> Window -> IO WindowAttributes
 getWindowAttributes d w = alloca $ \p -> do
-    _ <- throwIf (0==) (const "getWindowAttributes") $ xGetWindowAttributes d w p
+    _ <- throwIfZero "getWindowAttributes" $ xGetWindowAttributes d w p
     peek p
 
 -- | interface to the X11 library function @XChangeWindowAttributes()@.

--- a/Graphics/X11/Xlib/Extras.hsc
+++ b/Graphics/X11/Xlib/Extras.hsc
@@ -937,6 +937,7 @@ queryTree d w =
 -- TODO: this data type is incomplete wrt. the C struct
 data WindowAttributes = WindowAttributes
             { wa_x, wa_y, wa_width, wa_height, wa_border_width :: CInt
+            , wa_colormap :: Colormap
             , wa_map_state :: CInt
             , wa_override_redirect :: Bool
             }
@@ -959,6 +960,7 @@ instance Storable WindowAttributes where
                 `ap` (#{peek XWindowAttributes, width            } p)
                 `ap` (#{peek XWindowAttributes, height           } p)
                 `ap` (#{peek XWindowAttributes, border_width     } p)
+                `ap` (#{peek XWindowAttributes, colormap         } p)
                 `ap` (#{peek XWindowAttributes, map_state        } p)
                 `ap` (#{peek XWindowAttributes, override_redirect} p)
     poke p wa = do
@@ -967,6 +969,7 @@ instance Storable WindowAttributes where
         #{poke XWindowAttributes, width            } p $ wa_width wa
         #{poke XWindowAttributes, height           } p $ wa_height wa
         #{poke XWindowAttributes, border_width     } p $ wa_border_width wa
+        #{poke XWindowAttributes, colormap         } p $ wa_colormap wa
         #{poke XWindowAttributes, map_state        } p $ wa_map_state wa
         #{poke XWindowAttributes, override_redirect} p $ wa_override_redirect wa
 

--- a/Graphics/X11/Xlib/Extras.hsc
+++ b/Graphics/X11/Xlib/Extras.hsc
@@ -938,6 +938,7 @@ queryTree d w =
 data WindowAttributes = WindowAttributes
             { wa_x, wa_y, wa_width, wa_height, wa_border_width :: CInt
             , wa_colormap :: Colormap
+            , wa_map_installed :: Bool
             , wa_map_state :: CInt
             , wa_override_redirect :: Bool
             }
@@ -961,6 +962,7 @@ instance Storable WindowAttributes where
                 `ap` (#{peek XWindowAttributes, height           } p)
                 `ap` (#{peek XWindowAttributes, border_width     } p)
                 `ap` (#{peek XWindowAttributes, colormap         } p)
+                `ap` (#{peek XWindowAttributes, map_installed    } p)
                 `ap` (#{peek XWindowAttributes, map_state        } p)
                 `ap` (#{peek XWindowAttributes, override_redirect} p)
     poke p wa = do
@@ -970,6 +972,7 @@ instance Storable WindowAttributes where
         #{poke XWindowAttributes, height           } p $ wa_height wa
         #{poke XWindowAttributes, border_width     } p $ wa_border_width wa
         #{poke XWindowAttributes, colormap         } p $ wa_colormap wa
+        #{poke XWindowAttributes, map_installed    } p $ wa_map_installed wa
         #{poke XWindowAttributes, map_state        } p $ wa_map_state wa
         #{poke XWindowAttributes, override_redirect} p $ wa_override_redirect wa
 

--- a/Graphics/X11/Xlib/Extras.hsc
+++ b/Graphics/X11/Xlib/Extras.hsc
@@ -978,7 +978,7 @@ foreign import ccall unsafe "XlibExtras.h XGetWindowAttributes"
 
 getWindowAttributes :: Display -> Window -> IO WindowAttributes
 getWindowAttributes d w = alloca $ \p -> do
-    _ <- xGetWindowAttributes d w p
+    _ <- throwIf (0==) (const "getWindowAttributes") $ xGetWindowAttributes d w p
     peek p
 
 -- | interface to the X11 library function @XChangeWindowAttributes()@.


### PR DESCRIPTION
This as a first step to try and change XMonad to look up border colors using the window's color map, rather than the default color map.

See [XMonad issue 581](https://code.google.com/p/xmonad/issues/detail?id=581) and this [mailing list thread](http://thread.gmane.org/gmane.comp.lang.haskell.xmonad/14524/focus=14623).

Note that I have close to zero experience with Haskell and X11 programming, so the only testing I could figure out how to do was simply building the code.