### PR TITLE
Add XRRGetMonitors binding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
 
 before_install:
+ - sudo apt-get -qq update
+ - sudo apt-get install -y libxrandr-dev
  - unset CC
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 


### PR DESCRIPTION
RandR 1.5 adds a nice function to get information on active monitors.

I have managed to write a small test which shows that the pulled code works correctly. However, I'm not so familiar with FFI, I have just repeated the logic I saw in other functions, so please review it with caution.
