### PR TITLE
Xrandr XFree() fixes

### DIFF
--- a/Graphics/X11/Xrandr.hsc
+++ b/Graphics/X11/Xrandr.hsc
@@ -418,7 +418,6 @@ xrrConfigSizes config =
                                     sizes <- if nsizes == 0
                                                 then return Nothing
                                                 else peekArray (fromIntegral nsizes) p >>= return . Just
-                                    _ <- xFree p
                                     return sizes
 foreign import ccall "XRRConfigSizes"
   cXRRConfigSizes :: XRRScreenConfiguration -> Ptr CInt -> IO (Ptr XRRScreenSize)
@@ -433,7 +432,6 @@ xrrConfigRates config size_index =
                                     rates <- if nrates == 0
                                                 then return Nothing
                                                 else peekArray (fromIntegral nrates) p >>= return . Just
-                                    _ <- xFree p
                                     return rates
 foreign import ccall "XRRConfigRates"
   cXRRConfigRates :: XRRScreenConfiguration -> CInt -> Ptr CInt -> IO (Ptr CShort)
@@ -486,7 +484,6 @@ xrrSizes dpy screen =
                                     sizes <- if nsizes == 0
                                                 then return Nothing
                                                 else peekArray (fromIntegral nsizes) p >>= return . Just
-                                    _ <- xFree p
                                     return sizes
 foreign import ccall "XRRSizes"
   cXRRSizes :: Display -> CInt -> Ptr CInt -> IO (Ptr XRRScreenSize)
@@ -501,7 +498,6 @@ xrrRates dpy screen size_index =
                                     rates <- if nrates == 0
                                                 then return Nothing
                                                 else peekArray (fromIntegral nrates) p >>= return . Just
-                                    _ <- xFree p
                                     return rates
 foreign import ccall "XRRRates"
   cXRRRates :: Display -> CInt -> CInt -> Ptr CInt -> IO (Ptr CShort)

--- a/Graphics/X11/Xrandr.hsc
+++ b/Graphics/X11/Xrandr.hsc
@@ -676,7 +676,9 @@ xrrGetOutputProperty dpy rro prop offset len delete preferPending reqType = with
             32 -> peekArray nitems (castPtr ptr :: Ptr Word32)
             _  -> error $ "impossible happened: prop format is not in 0,8,16,32 (" ++ show format ++ ")"
 
-          _ <- xFree ptr
+          _ <- if format /= 0
+                  then xFree ptr
+                  else return 0
 
           typ <- peek actualTypep
           bytesAfter <- peek bytesAfterp


### PR DESCRIPTION
Many of the xrr\* functions call XFree() when inappropriate.

It may fail silently in most cases, but on Debian unstable at least, I get reliable crashes:

```
λ> getScreenSizes
*** Error in `/home/chipb/.cabal/bin/ghci-ng': munmap_chunk(): invalid pointer: 0x00007fa46800c918 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x71ff5)[0x7fa473f26ff5]
/lib/x86_64-linux-gnu/libc.so.6(+0x77946)[0x7fa473f2c946]
/usr/lib/x86_64-linux-gnu/libX11.so.6(XFree+0x9)[0x7fa4619938c9]
/usr/lib/haskell-packages/ghc/lib/x86_64-linux-ghc-7.10.3/X11-1.6.1.2-LN1z6AJRA5dI5d2mzKRchU/libHSX11-1.6.1.2-LN1z6AJRA5dI5d2mzKRchU-ghc7.10.3.so(+0x1fba04)[0x7fa46208fa04]
======= Memory map: ========
    ...
```

There seems to be at least one other person affected by this, too: https://www.reddit.com/r/haskellquestions/comments/3zozx3/how_to_use_properly_the_xrandr_bindings/cyp66v8
