### PR TITLE
XF86.hsc: drop stray trailing ','

### DIFF
--- a/Graphics/X11/ExtraTypes/XF86.hsc
+++ b/Graphics/X11/ExtraTypes/XF86.hsc
@@ -708,7 +708,7 @@ module Graphics.X11.ExtraTypes.XF86
 #else
          -- Skipping XF86XK_UWB because your X doesn't define it
 #endif
-#ifdef XF86XK_AudioForward,
+#ifdef XF86XK_AudioForward
          xF86XK_AudioForward,        --  Fast-forward audio track
 #else
          -- Skipping XF86XK_AudioForward because your X doesn't define it


### PR DESCRIPTION
Noticed by gcc when package was compiled:
    Preprocessing library X11-1.8...
    XF86.hsc:711:27: warning: extra tokens at end of #ifdef directive
    XF86.hsc: In function 'main':
    XF86.hsc:711:27: warning: extra tokens at end of #ifdef directive
    XF86.hsc:711:27: warning: extra tokens at end of #ifdef directive

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>