### PR TITLE
Check return code of xQueryTree and throw on error.

### DIFF
--- a/Graphics/X11/Xlib/Extras.hsc
+++ b/Graphics/X11/Xlib/Extras.hsc
@@ -952,7 +952,7 @@ queryTree d w =
     alloca $ \parent_return ->
     alloca $ \children_return ->
     alloca $ \nchildren_return -> do
-        _ <- xQueryTree d w root_return parent_return children_return nchildren_return
+        _ <- throwIfZero "queryTree" $ xQueryTree d w root_return parent_return children_return nchildren_return
         p <- peek children_return
         n <- fmap fromIntegral $ peek nchildren_return
         ws <- peekArray n p


### PR DESCRIPTION
Fixes issue #56, where uninitialized memory would be accessed
after xQueryTree failure.