### PR TITLE
Mention dependency on libXScrnSaver more prominently

### DIFF
--- a/Graphics/X11/XScreenSaver.hsc
+++ b/Graphics/X11/XScreenSaver.hsc
@@ -10,6 +10,9 @@
 -- Stability : provisional
 -- Portability: portable
 --
+-- Note that most functions in this module are only exported if
+-- the libXScrnSaver library was available at the time of compilation.
+--
 --------------------------------------------------------------------
 --
 -- Interface to XScreenSaver API

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ or
 
 You will need development versions of at least the X11, xrandr, and Xinerama
 libraries installed for the build to succeed; having the development version of
-the XScreenSaver library will enable some optional bindings.
+the XScreenSaver library (libXScrnSaver) will enable some optional bindings.


### PR DESCRIPTION
If compiled without the libXScrnSaver library, the module `Graphics.X11.XScreenSaver` will only export a single function, namely `compiledWithXScreenSaver`. However, the Hackage documentation doesn't reflect this fact. This pull request adds a small note to the module preamble.

On a related note, I don't quite get the meaning of the `compiledWithXScreenSaver` constant. How can we sensibly work with it? If its false, then almost no other functions are exported.

This pull request is joint work with @xaverdh.