### PR TITLE
Place #include directive sensibly

### DIFF
--- a/Graphics/X11/ExtraTypes/XF86.hsc
+++ b/Graphics/X11/ExtraTypes/XF86.hsc
@@ -19,6 +19,7 @@
 -- Presumably XFree86/X.org has copyright on the header but it's not
 -- explicit in the file.
 
+#include "HsAllKeysyms.h"
 
 module Graphics.X11.ExtraTypes.XF86
         (
@@ -911,8 +912,6 @@ module Graphics.X11.ExtraTypes.XF86
         ) where
 
 import Graphics.X11.Types
-
-#include "HsAllKeysyms.h"
 
 #ifdef XF86XK_ModeLock
 xF86XK_ModeLock             :: KeySym


### PR DESCRIPTION
Previously, the `#include` was placed after the module exports - which meant that some things that should have been conditionally exported were not exported. This caused complications when cross-compiling (i.e. using `hsc2hs` with `-x`).

This fixes things by placing the `#include` directive above the relevant `#ifdef`s. 