### PR TITLE
Add setClientMessageEvent'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log / Release Notes
 
+## unknown
+
+  * Added `setClientMessageEvent'` (#71)
+
 ## 1.9.2 (2020-08-25)
 
   * Make sure that X11 search paths determined by autoconf are actually passed


### PR DESCRIPTION
The existing setClientMessageEvent can't be used to send EWMH
_NET_WM_STATE client messages as they need more than 2 items in data.
Furthermore, it doesn't set all of data and thus sends whatever was in
memory before.

The motivation here is that we want xmonad to be configurable to ignore some _NET_ACTIVE_WINDOW requests to prevent e.g. browsers from stealing focus, but it's nice to make that focus request visible somehow. And since the urgency handling machinery is already very configurable in xmonad, the easiest way to plug into it is to send a message to ourselves.

A draft of that is here: https://github.com/liskin/xmonad-contrib/commit/7bac0959ef99c5ad8988e6b62c819d5123c154da
Usage example: https://github.com/liskin/dotfiles/commit/18dfd71861031cb9cbab7d69d931ae3433acac8a#diff-f3bd9f70ef878f30362ff11bbea7fd1d0d6abde1b4befa44b18cce5a27456204R257

Related discussions:
https://github.com/xmonad/xmonad-contrib/pull/109#issuecomment-259766760
https://github.com/xmonad/xmonad-contrib/pull/110#issuecomment-261844606
https://github.com/xmonad/xmonad-contrib/issues/396
https://github.com/xmonad/xmonad-contrib/pull/399
