### PR TITLE
Xrandr fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## unknown
 
   * Fixed type of `xrrUpdateConfiguration`
+  * Fixed bottom when deserializing XRRNotifyEvent in `getEvent`
 
 ## 1.9.2 (2020-08-25)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log / Release Notes
 
+## unknown
+
+  * Fixed type of `xrrUpdateConfiguration`
+
 ## 1.9.2 (2020-08-25)
 
   * Make sure that X11 search paths determined by autoconf are actually passed

--- a/Graphics/X11/Xlib/Extras.hsc
+++ b/Graphics/X11/Xlib/Extras.hsc
@@ -768,7 +768,7 @@ getEvent p = do
             type_ == rrEventBase + rrNotify -> do
             window   <- #{peek XRRNotifyEvent, window  } p
             subtype  <- #{peek XRRNotifyEvent, subtype } p
-            let subtype_ = fromIntegral subtype_
+            let subtype_ = fromIntegral subtype
             case () of
                 _ | subtype_ == rrNotifyCrtcChange -> do
                     crtc           <- #{peek XRRCrtcChangeNotifyEvent, crtc     } p

--- a/Graphics/X11/Xrandr.hsc
+++ b/Graphics/X11/Xrandr.hsc
@@ -460,10 +460,10 @@ xrrSelectInput dpy window mask = cXRRSelectInput dpy window (fromIntegral mask)
 foreign import ccall "XRRSelectInput"
   cXRRSelectInput :: Display -> Window -> CInt -> IO ()
 
-xrrUpdateConfiguration :: XEvent -> IO CInt
+xrrUpdateConfiguration :: XEventPtr -> IO CInt
 xrrUpdateConfiguration = cXRRUpdateConfiguration
 foreign import ccall "XRRUpdateConfiguration"
-  cXRRUpdateConfiguration :: XEvent -> IO CInt
+  cXRRUpdateConfiguration :: XEventPtr -> IO CInt
 
 xrrRotations :: Display -> CInt -> IO (Rotation, Rotation)
 xrrRotations dpy screen =


### PR DESCRIPTION
#### [Fix type of xrrUpdateConfiguration](../commit/dca1ffbd1ad1fb92348703beaac2dd6d65702e6d)

XRRUpdateConfiguration takes XEvent* so it should be XEventPtr. There's
no good way to get XEvent anyway.

#### [Fix bottom when deserializing XRRNotifyEvent in getEvent](../commit/1d8bba26bc7aa9d3468bdf106979382061f0ee56)

This would crash any program that does

    xrrSelectInput dpy root rrCrtcChangeNotifyMask

and later calls getEvent on the received event.