### PR TITLE
Add `setClassHint`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
   * Added `xrrGetMonitors` and `XRRMonitorInfo` (#42)
 
+  * Added `setClassHint` (#76)
+
 ## 1.9.2 (2020-08-25)
 
   * Make sure that X11 search paths determined by autoconf are actually passed

--- a/Graphics/X11/Xlib/Extras.hsc
+++ b/Graphics/X11/Xlib/Extras.hsc
@@ -1515,6 +1515,18 @@ getClassHint d w =  allocaBytes (#{size XClassHint}) $ \ p -> do
 foreign import ccall unsafe "XlibExtras.h XGetClassHint"
     xGetClassHint :: Display -> Window -> Ptr ClassHint -> IO Status
 
+-- | Set the @WM_CLASS@ property for the given window.
+setClassHint :: Display -> Window -> ClassHint -> IO ()
+setClassHint dpy win (ClassHint name cl) =
+    allocaBytes (#{size XClassHint}) $ \ptr -> do
+        withCString name $ \c_name -> withCString cl $ \c_cl -> do
+            #{poke XClassHint, res_name } ptr c_name
+            #{poke XClassHint, res_class} ptr c_cl
+            xSetClassHint dpy win ptr
+
+foreign import ccall unsafe "XlibExtras.h XSetClassHint"
+    xSetClassHint :: Display -> Window -> Ptr ClassHint -> IO ()
+
 ------------------------------------------------------------------------
 -- WM Hints
 


### PR DESCRIPTION
Add an interface for `XSetClassHint()`, the counterpart for the
already available `XGetClassHint()`.  It is specifically needed inside
xmonad-contrib to set the `WM_CLASS` property of certain windows we
spawn.

Related:
  - xmonad/xmonad-contrib#526
  - xmonad/xmonad-contrib#369