### PR TITLE
Mark some blocking FFI imports as "safe" (fix high cpu usage in xmonad)

### DIFF
--- a/Graphics/X11/Xlib/Event.hsc
+++ b/Graphics/X11/Xlib/Event.hsc
@@ -494,7 +494,7 @@ foreign import ccall unsafe "HsXlib.h XSendEvent"
                 XEventPtr -> IO Status
 
 -- | interface to the X11 library function @XWindowEvent()@.
-foreign import ccall unsafe "HsXlib.h XWindowEvent"
+foreign import ccall safe "HsXlib.h XWindowEvent"
         windowEvent :: Display -> Window -> EventMask -> XEventPtr -> IO ()
 
 -- | interface to the X11 library function @XCheckWindowEvent()@.
@@ -503,7 +503,7 @@ foreign import ccall unsafe "HsXlib.h XCheckWindowEvent"
                 XEventPtr -> IO Bool
 
 -- | interface to the X11 library function @XMaskEvent()@.
-foreign import ccall unsafe "HsXlib.h XMaskEvent"
+foreign import ccall safe "HsXlib.h XMaskEvent"
         maskEvent :: Display -> EventMask -> XEventPtr -> IO ()
 
 -- | interface to the X11 library function @XCheckMaskEvent()@.
@@ -524,7 +524,7 @@ foreign import ccall unsafe "HsXlib.h XPutBackEvent"
         putBackEvent :: Display -> XEventPtr -> IO ()
 
 -- | interface to the X11 library function @XPeekEvent()@.
-foreign import ccall unsafe "HsXlib.h XPeekEvent"
+foreign import ccall safe "HsXlib.h XPeekEvent"
         peekEvent :: Display -> XEventPtr -> IO ()
 
 -- XFilterEvent omitted (can't find documentation)


### PR DESCRIPTION
GHC RTS doesn't expect "unsafe" FFI calls to block, so when the parallel garbage collector kicks in, blocking unsafe calls cause all the other GC threads to wait in a busy loop.

This can be reproduced by using XMonad.Actions.Submap (which uses XMaskEvent in a blocking fashion) together with +RTS -N. To confirm the parallel GC hypothesis, +RTS -N -qg (disables parallel GC) works fine. (For more details about the reproducer, see the linked xmonad-contrib issues.)

The fix is to mark potentially blocking calls "safe", as XNextEvent has been for the last 14 years and as documented in: https://downloads.haskell.org/~ghc/9.0.1/docs/html/users_guide/exts/ffi.html#foreign-imports-and-multi-threading

Fixes: https://github.com/xmonad/xmonad-contrib/issues/262
Fixes: https://github.com/xmonad/xmonad-contrib/issues/483
Related: 344d94279c68 ("XNextEvent should be *safe*, for correct behaviour with threads")