### PR TITLE
TimeVal's members are 64 bit, per the unix package

### DIFF
--- a/Graphics/X11/Xlib/Event.hsc
+++ b/Graphics/X11/Xlib/Event.hsc
@@ -71,6 +71,7 @@ import Data.Data
 #endif
 
 #include "HsXlib.h"
+#include <sys/time.h>
 
 {-# CFILES cbits/fdset.c #-}
 
@@ -398,7 +399,7 @@ get_ConfigureEvent p = peekXConfigureEvent (castPtr p)
 -- Returns True if timeout occurs.
 waitForEvent :: Display -> Word32 -> IO Bool
 waitForEvent display usecs =
-        with (TimeVal (usecs `div` 1000000) (usecs `mod` 1000000)) $ \ tv_ptr ->
+        with (TimeVal (fromIntegral usecs `div` 1000000) (fromIntegral usecs `mod` 1000000)) $ \ tv_ptr ->
         allocaBytes #{size fd_set} $ \ readfds ->
         allocaBytes #{size fd_set} $ \ nofds -> do
         let fd = connectionNumber display
@@ -429,7 +430,7 @@ gettimeofday_in_milliseconds =
         TimeVal sec usec <- peek tv_ptr
         return (toInteger sec * 1000 + toInteger usec `div` 1000)
 
-data TimeVal = TimeVal Word32 Word32
+data TimeVal = TimeVal CLong CLong
 
 instance Storable TimeVal where
         alignment _ = #{size int}

--- a/X11.cabal
+++ b/X11.cabal
@@ -1,5 +1,5 @@
 name:               X11
-version:            1.10.3.9
+version:            1.10.3.10
 synopsis:           A binding to the X11 graphics library
 description:        A Haskell binding to the X11 graphics library. The binding is a direct
                     translation of the C binding; for documentation of these calls, refer


### PR DESCRIPTION
Fixes #99.
Eventually we should update `waitForEvent`'s type signature to match.