### PR TITLE
Add `getWindowPropertyPtr` returning `IO (Maybe (ForeignPtr a, Int))`

### DIFF
--- a/Graphics/X11/Xlib/Internal.hsc
+++ b/Graphics/X11/Xlib/Internal.hsc
@@ -12,9 +12,10 @@
 --
 -----------------------------------------------------------------------------
 
-module Graphics.X11.Xlib.Internal (xFree) where
+module Graphics.X11.Xlib.Internal (xFree, xFreePtr) where
 
 import Foreign
 import Foreign.C.Types
 
 foreign import ccall unsafe "XFree" xFree :: Ptr a -> IO CInt
+foreign import ccall unsafe "&XFree" xFreePtr :: FinalizerPtr a


### PR DESCRIPTION
This is a draft for the concept discussed in #52. Actually, I did not even test it (beyond building). Quite likely, I have cheated when setting the type of `xFreePtr` to `FinalizerPtr a = FunPtr (Ptr a → IO ())` instead of `FunPtr (Ptr a → IO Int)`. I do not know, what would be a clean solution here.

As I am not very experienced with regards to Haskell building and testing, I would appreciate any help.